### PR TITLE
Bump activesupport to 6.x

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -11,7 +11,7 @@ GitHubChangelogGenerator::RakeTask.new :changelog do |config|
   config.project = 'internet_security_event'
   config.since_tag = 'v1.2.1'
   require 'internet_security_event/version'
-  config.future_release = InternetSecurityEvent::VERSION
+  config.future_release = "v#{InternetSecurityEvent::VERSION}"
 end
 
 task default: :spec


### PR DESCRIPTION
78298562bd58d83522e4e7575d8e4e5be28db8db bumped activesupport to 6.x to fix issues with old versions of activesupport and github_changelog_generator. This does not appear in the CHANGELOG, so use the excuse of this missing piece in that commit to create a PR which fix a small issue to document a more important change.

For the record, activesupport 7.x dropped version of older versions of Ruby we currently support, so for now stick with 6.x.

Bumping this kind of dependencies is a major move because we need a new release of this gem for github_changelog_generator to be usable in projects depending on this one.