### PR TITLE
Switch to ActiveSupport 7.x

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,9 +26,6 @@ jobs:
     strategy:
       matrix:
         ruby:
-          - "2.6"
-          - "2.7"
-          - "3.0"
           - "3.1"
           - "3.2"
     name: Ruby ${{ matrix.ruby }}

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,7 +1,7 @@
 AllCops:
   AllowSymlinksInCacheRootDirectory: true
 
-require:
+plugins:
   - rubocop-rake
   - rubocop-rspec
 
@@ -9,7 +9,7 @@ Layout/HashAlignment:
   EnforcedColonStyle: table
   EnforcedHashRocketStyle: table
 
-Metrics/LineLength:
+Layout/LineLength:
   Max: 160
 
 Style/Documentation:

--- a/internet_security_event.gemspec
+++ b/internet_security_event.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |spec|
   spec.summary       = 'Build events describing the status of various internet services'
   spec.homepage      = 'https://github.com/smortex/internet_security_event'
   spec.license       = 'MIT'
-  spec.required_ruby_version = Gem::Requirement.new('>= 2.6.0')
+  spec.required_ruby_version = Gem::Requirement.new('>= 3.1.0')
 
   # Specify which files should be added to the gem when it is released.
   # The `git ls-files -z` loads the files in the RubyGem that have been added into git.
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'activesupport', '~> 6.0'
+  spec.add_dependency 'activesupport', '~> 7.0'
 
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'github_changelog_generator'


### PR DESCRIPTION
Newer Ruby versions will log warnings about bigdecimal being removed
form the Ruby standard library.  ActiveSupport 7 has an explicit
dependency on it, but we have to bump the required ruby version.
